### PR TITLE
Update DateFormat Mask to use lowercase "d".

### DIFF
--- a/org/camden/ups/timeintransitservice.cfc
+++ b/org/camden/ups/timeintransitservice.cfc
@@ -364,7 +364,7 @@ Copyright 2007 Kurt Bonnet
       <MonetaryValue>#xmlFormat(arguments.packageValue)#</MonetaryValue>
    </InvoiceLineTotal>
    </cfif>
-   <PickupDate>#dateFormat(arguments.pickupday, "YYYYMMDD")#</PickupDate>
+   <PickupDate>#dateFormat(arguments.pickupday, "yyyymmdd")#</PickupDate>
    <cfif arguments.packageDocumentsOnly ><DocumentsOnlyIndicator/></cfif>
 </TimeInTransitRequest>
 	</cfoutput>


### PR DESCRIPTION
Fix DateFormat mask to use lowercase "d" due to ColdFusion 2021 breaking change.  ("D" now outputs "day of year".)

More info here:
https://www.carehart.org/blog/client/index.cfm/2020/11/24/breaking_change_in_cf2021_dateformat_D_vs_d